### PR TITLE
TypeScript 3.9 fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,5 +36,6 @@
         "editor.codeActionsOnSave": {
             "source.organizeImports": true
         }
-    }
+    },
+    "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2728,9 +2728,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
-      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+      "integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "tslint": "^5.20.1",
     "tslint-config-airbnb": "^5.11.2",
     "typeorm": "^0.2.21",
-    "typescript": "^3.7.3"
+    "typescript": "^3.9.2"
   },
   "prettier": {
     "singleQuote": true,

--- a/src/aws/types.ts
+++ b/src/aws/types.ts
@@ -156,12 +156,12 @@ export interface LambdaCallback {
 
 export type LambdaEvent = (
   PingEvent
-  & RemoteEvent
-  & LambdaApiEvent
-  & LambdaS3Event
-  & LambdaSQSEvent
-  & LambdaDynamoEvent
-  & LambdaScheduleEvent
+  | RemoteEvent
+  | LambdaApiEvent
+  | LambdaS3Event
+  | LambdaSQSEvent
+  | LambdaDynamoEvent
+  | LambdaScheduleEvent
 );
 
 export interface LambdaHandler {


### PR DESCRIPTION
Typescript 3.9 introduces [a breaking change in which incompatible intersection types are reduced to the `never` type](https://devblogs.microsoft.com/typescript/announcing-typescript-3-9/#breaking-changes). This mean that the `LambdaEvent` type is reduced to `never`, which can break things as [nothing can be assigned to `never`](https://www.typescriptlang.org/docs/handbook/basic-types.html#never).

This pull request changes `LambdaEvent` to a union type and uses type guards to figure out the correct type when handling events.