### PR TITLE
Error message on missing relation

### DIFF
--- a/src/metadata/relation.ts
+++ b/src/metadata/relation.ts
@@ -275,7 +275,7 @@ export class RelationMetadata<T = any> extends FieldMetadata implements IRelatio
     this.joinColumns = this.joinOptions.map(opt => entity.members[opt.name] as ColumnMetadata);
     const inverseEntity = this.typeFunction();
     this.inverseEntityMetadata = database.entities.find(e => e.target === inverseEntity);
-    if (!this.inverseSide) {
+    if (!this.inverseSide || !this.inverseEntityMetadata) {
       throw new TypeError(`Missing inverse relation on ${this.relationType} `
         + `[${entity.name}.${this.propertyName}] => [${inverseEntity.name}]`);
     }


### PR DESCRIPTION
If a relation was not exported properly but was referenced by another entity, we would get the cryptic error message:

`TypeError: Cannot read property 'members' of undefined`

This commit fixes it so that the "missing inverse relation" error is thrown in this scenario so that whoever reads the message has a better idea of what went wrong.