### PR TITLE
Correct error on missing event

### DIFF
--- a/src/core/instance.ts
+++ b/src/core/instance.ts
@@ -401,11 +401,13 @@ export class CoreInstance implements CoreContainer {
       let route = EventRouteMetadata.route(req.source, req.resource);
       const alias = this.config.resources && this.config.resources[req.resource];
       let targets = Registry.EventRouteMetadata[route];
-      if (!targets) {
+      if (!targets && alias) {
         route = EventRouteMetadata.route(req.source, alias);
         targets = Registry.EventRouteMetadata[route];
       }
-      if (!targets) new Forbidden(`Event handler not found [${route}] [${req.object}]`);
+      if (!targets) {
+        throw new Forbidden(`Event handler not found [${route}] [${req.object}]`);
+      }
 
       const result: EventResult = {
         status: null,


### PR DESCRIPTION
Don't try using a resource alias if no alias was found and throw correctly if no targets are found (otherwise the error would be something like "targets is not iterable").